### PR TITLE
未指定aur安装源

### DIFF
--- a/docs/apps/daily.md
+++ b/docs/apps/daily.md
@@ -354,7 +354,7 @@ yay -S calibre-git
    ::: code-group-item aur (git)
 
    ```sh
-   yay -S flameshot-git
+   yay -S aur/flameshot-git
    ```
 
    :::


### PR DESCRIPTION
仅仅修复了火焰截图的aur/git的安装代码，仍存在许多地方未制定aur/