### PR TITLE
code-group: fix display errors related to code-group

### DIFF
--- a/docs/app/common/collaboration.md
+++ b/docs/app/common/collaboration.md
@@ -47,29 +47,21 @@ scrcpy 有以下优点：
 
 1. 安装 [scrcpy](https://aur.archlinux.org/packages/scrcpy/)<sup>cn / aur</sup> 以及 [安卓工具包](https://archlinux.org/packages/community/x86_64/android-tools/)：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S scrcpy android-tools
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/scrcpy android-tools
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S scrcpy-git android-tools
    ```
 
    :::
-   ::::
 
 2. 打开安卓设备的 `设置` > `开发人员选项`（多次点击 `关于手机（平板）` 中的 `版本号`，提示处在 `开发者模式` 后即可在设置中找到）> 打开 `USB 调试`：
 
@@ -219,22 +211,18 @@ scrcpy --turn-screen-off --stay-awake
 
 若亮屏是常用选项，可将这个命令设置为 scrcpy 的别名（alias）。只需要使用以下命令在 `~/.zshrc` 或者 `~/.bashrc` 中添加如下内容 > 重新打开终端或者 `source` 该文件即可：
 
-:::: code-group
-::: code-group-item bash
+::: code-group
 
-```sh
+```sh [bash]
 echo 'alias scrcpy="scrcpy --turn-screen-off --stay-awake"' >> ~/.bashrc
 ```
 
-:::
-::: code-group-item zsh
 
-```sh
+```sh [zsh]
 echo 'alias scrcpy="scrcpy --turn-screen-off --stay-awake"' >> ~/.zshrc
 ```
 
 :::
-::::
 
 ## 🍎 苹果设备投屏（UxPlay）
 
@@ -303,24 +291,17 @@ sudo systemctl enable avahi-daemon.service
 
 或者使用以下命令创建 `uxplay` 命令的别名（alias），只需要使用以下命令在 `~/.zshrc` 或者 `~/.bashrc` 中添加如下内容 > 重新打开终端或者 `source` 该文件即可：
 
-:::: code-group
-::: code-group-item bash
+::: code-group
 
-```sh
+```sh [bash]
 echo 'alias uxplay="sudo systemctl start avahi-daemon.service && uxplay"' >> ~/.bashrc
 ```
 
-:::
-::: code-group-item zsh
-
-```sh
+```sh [zsh]
 echo 'alias uxplay="sudo systemctl start avahi-daemon.service && uxplay"' >> ~/.zshrc
 ```
 
 :::
-::::
-
-:::::
 
 ::: tip ℹ️ 提示
 
@@ -336,29 +317,21 @@ echo 'alias uxplay="sudo systemctl start avahi-daemon.service && uxplay"' >> ~/.
 
 1. 安装 [KDE Connect](https://archlinux.org/packages/extra/x86_64/kdeconnect/)<sup>extra / cn / aur</sup> 及其相关可选依赖：
 
-   :::: code-group
-   ::: code-group-item extra
+   ::: code-group
 
-   ```sh
+   ```sh [extra]
    sudo pacman -S kdeconnect sshfs
    ```
 
-   :::
-   ::: code-group-item cn (git)
-
-   ```sh
+   ```sh [cn (git)]
    sudo pacman -S skdeconnect-git sshfs
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S aur/kdeconnect-git sshfs
    ```
 
    :::
-   ::::
 
 2. 移动端可在 [Google Play](https://play.google.com/store/apps/details?id=org.kde.kdeconnect_tp) [App Store](https://apps.apple.com/us/app/kde-connect/id1580245991)下载并安装
 

--- a/docs/app/common/communication.md
+++ b/docs/app/common/communication.md
@@ -42,36 +42,25 @@ Telegram 有两种加密模式：
 
 1. 安装 `Telegram`<sup>community / cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S telegram-desktop
    ```
 
-   :::
-   ::: code-group-item cn (git)
-
-   ```sh
+   ```sh [cn (git)]
    sudo pacman -S telegram-desktop-git
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S telegram-desktop-bin
    ```
 
-   :::
-   ::: code-group-item aur（dev）
-
-   ```sh
+   ```sh [aur（dev）]
    yay -S telegram-desktop-bin-dev
    ```
 
    :::
-   ::::
 
    ![telegram](../../assets/app/common/communication/telegram.png)
 
@@ -205,36 +194,25 @@ Skype 是一款通信应用软件，可通过互联网为电脑、平板电脑�
 
 安装 [Skype](https://www.skype.com/zh-Hans/)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S skypeforlinux-stable-bin
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/skypeforlinux-stable-bin
 ```
 
-:::
-::: code-group-item cn（preview）
-
-```sh
+```sh [cn（preview）]
 sudo pacman -S skypeforlinux-preview-bin
 ```
 
-:::
-::: code-group-item aur（preview）
-
-```sh
+```sh [aur（preview）]
 yay -S aur/skypeforlinux-preview-bin
 ```
 
 :::
-::::
 
 ![skype](../../assets/app/common/communication/skype.png)
 
@@ -285,22 +263,17 @@ sudo pacman -S teamspeak3
 
 安装 [Slack](https://aur.archlinux.org/packages/slack-desktop/)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S slack-desktop
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/slack-desktop
 ```
 
 :::
-::::
 
 ![slack](../../assets/app/common/communication/slack.png)
 
@@ -360,21 +333,16 @@ KDE 用户使用 mailspring 前需要安装`gnome-keyring`
 
 安装 [mailspring](https://github.com/Foundry376/Mailspring)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S mailspring
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/mailspring
 ```
 
 :::
-::::
 
 ![mailspring](https://raw.githubusercontent.com/Foundry376/Mailspring/master/screenshots/hero_graphic_mac%402x.png)

--- a/docs/app/common/daily.md
+++ b/docs/app/common/daily.md
@@ -78,29 +78,21 @@ Brave 是一个基于 Chromium 网页浏览器及其 Blink 排版引擎的自由
 
 安装 [Brave](https://archlinux.org/packages/extra/x86_64/falkon/)<sup>cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S brave-bin
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/brave-bin
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S brave-git
 ```
 
 :::
-::::
 
 ![brave](../../assets/app/common/daily/brave.png)
 
@@ -110,22 +102,17 @@ Falkon 是 KDE 开发的一款全新的 Qt 网络浏览器。它是一款轻量�
 
 安装 [Falkon](https://archlinux.org/packages/extra/x86_64/falkon/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S falkon
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S falkon-git
 ```
 
 :::
-::::
 
 ![falkon](../../assets/app/common/daily/falkon.png)
 
@@ -135,22 +122,17 @@ yay -S falkon-git
 
 安装 [Tor 浏览器](https://aur.archlinux.org/packages/tor-browser/)<sup>cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S tor-browser
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S tor-browser
 ```
 
 :::
-::::
 
 ![tor](../../assets/app/common/daily/tor.png)
 
@@ -160,22 +142,17 @@ Microsoft Edge（微软前沿浏览器）是一个由微软研发的浏览器，
 
 安装 [Microsoft Edge](https://aur.archlinux.org/packages/microsoft-edge-stable-bin)<sup>EULA / aur</sup>：
 
-:::: code-group
-::: code-group-item aur（beta）
+::: code-group
 
-```sh
+```sh [aur（beta）]
 yay -S microsoft-edge-beta-bin
 ```
 
-:::
-::: code-group-item aur（dev）
-
-```sh
+```sh [aur（dev）]
 yay -S microsoft-edge-dev-bin
 ```
 
 :::
-::::
 
 ![edge](../../assets/app/common/daily/edge.png)
 
@@ -185,22 +162,17 @@ Google Chrome 是由 Google 开发的免费网页浏览器。Chrome 相应的开
 
 安装 [Google Chrome](https://aur.archlinux.org/packages/google-chrome/)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S google-chrome
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S google-chrome
 ```
 
 :::
-::::
 
 ![chrome](../../assets/app/common/daily/chrome.png)
 
@@ -212,29 +184,21 @@ Opera 软件公司为纳斯达克上市的挪威软件公司，现在已被中�
 
 安装 [Opera](https://archlinux.org/packages/community/x86_64/opera/)<sup>EULA / community / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S opera
 ```
 
-:::
-::: code-group-item cn（beta）
-
-```sh
+```sh [cn（beta）]
 sudo pacman -S opera-beta
 ```
 
-:::
-::: code-group-item aur（beta）
-
-```sh
+```sh [aur（beta）]
 yay -S aur/opera-beta
 ```
 
 :::
-::::
 
 ![opera](../../assets/app/common/daily/opera.png)
 
@@ -262,22 +226,17 @@ Okular 是 KDE 开发的一款功能丰富、轻巧快速的跨平台文档阅�
 
 安装 [Okular](https://archlinux.org/packages/extra/x86_64/okular/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S okular
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S okular-git
 ```
 
 :::
-::::
 
 ![okular](../../assets/app/common/daily/okular.png)
 
@@ -287,22 +246,17 @@ calibre 是一款功能强大且易于使用的电子书管理器。支持 epub�
 
 安装 [calibre](https://archlinux.org/packages/community/x86_64/calibre/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S calibre
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S calibre-git
 ```
 
 :::
-::::
 
 ![calibre](../../assets/app/common/daily/calibre.png)
 
@@ -336,29 +290,21 @@ yay -S calibre-git
 
 1. 安装 [火焰截图](https://archlinux.org/packages/community/x86_64/flameshot/)<sup>community / cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S flameshot
    ```
 
-   :::
-   ::: code-group-item cn (git)
-
-   ```sh
+   ```sh [cn (git)]
    sudo pacman -S flameshot-git
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S aur/flameshot-git
    ```
 
    :::
-   ::::
 
 2. 配置快捷键：
 
@@ -382,22 +328,17 @@ Spectacle 是 KDE 开发的用于抓取桌面截图的简单应用程序。它�
 
 安装 [Spectacle](https://archlinux.org/packages/extra/x86_64/spectacle/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S spectacle
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S spectacle-git
 ```
 
 :::
-::::
 
 ![spectacle](../../assets/app/common/daily/spectacle.png)
 
@@ -411,22 +352,17 @@ MEGA 是 Mega Limited 公司推出的一款云存储服务。2013 年 1 月 19 �
 
 1. 安装 [MEGA](https://aur.archlinux.org/packages/megasync)<sup>EULA / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S megasync
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/megasync
    ```
 
    :::
-   ::::
 
 2. 根据提示登录账户以及配置同步文件夹后即可：
 
@@ -490,22 +426,17 @@ Gwenview 是 KDE 出品的一款轻便易用的图像查看器，是浏览、显
 
 安装 [Gwenview](https://archlinux.org/packages/extra/x86_64/gwenview/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S gwenview
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S gwenview-git
 ```
 
 :::
-::::
 
 ![gwenview](../../assets/app/common/daily/gwenview.png)
 
@@ -515,22 +446,17 @@ nomacs 是一个免费的开源图像查看器，支持多平台。可以使用�
 
 安装 [nomacs](https://archlinux.org/packages/community/x86_64/nomacs/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S nomacs
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S nomacs-git
 ```
 
 :::
-::::
 
 ![nomacs-1](../../assets/app/common/daily/nomacs-1.png)
 
@@ -564,23 +490,18 @@ feh 是一款轻巧而功能强大的图像查看器，通过命令行操作，*
 
 1. 安装 [feh](https://archlinux.org/packages/extra/x86_64/feh/)<sup>extra / aur</sup>。若需要读取 SVG 图像，则还需要安装 [`imagemagick`](https://archlinux.org/packages/extra/x86_64/imagemagick/)：
 
-   :::: code-group
-   ::: code-group-item extra
+   ::: code-group
 
-   ```sh
+   ```sh [extra]
    sudo pacman -S feh imagemagick
 
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S feh-git imagemagick
    ```
 
    :::
-   ::::
 
 2. 通过以下命令使用 feh。feh 是高度可配置的。有关选项的完整列表，请运行 `feh --help` 或 `man feh`：
 

--- a/docs/app/common/media.md
+++ b/docs/app/common/media.md
@@ -36,36 +36,25 @@ sidebarDepth: 2
 
 安装 [`VLC`](https://archlinux.org/packages/extra/x86_64/vlc/)<sup>extra / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S vlc
 ```
 
-:::
-::: code-group-item cn (git)
-
-```sh
+```sh [cn (git)]
 sudo pacman -S vlc-git
 ```
 
-:::
-::: code-group-item aur（obs）
-
-```sh
+```sh [aur（obs）]
 yay -S vlc-luajit
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aur/vlc-git
 ```
 
 :::
-::::
 
 ![vlc](../../assets/app/common/media/vlc.png)
 
@@ -75,29 +64,21 @@ yay -S aur/vlc-git
 
 安装 [`mpv`](https://archlinux.org/packages/community/x86_64/mpv/)<sup>community / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S mpv
 ```
 
-:::
-::: code-group-item cn (git)
-
-```sh
+```sh [cn (git)]
 sudo pacman -S mpv-git
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aur/mpv-git
 ```
 
 :::
-::::
 
 ![mpv](../../assets/app/common/media/mpv.png)
 
@@ -119,22 +100,17 @@ sudo pacman -S dragon
 
 1. 安装 [`SMplayer`](https://archlinux.org/packages/community/x86_64/smplayer/)<sup>community / cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S smplayer
    ```
 
-   :::
-   ::: code-group-item aur（svn）
-
-   ```sh
+   ```sh [aur（svn）]
    yay -S smplayer-svn
    ```
 
    :::
-   ::::
 
 2. 默认的外观不太美观，可选安装皮肤 [`papirus-smplayer-theme-git`](https://github.com/PapirusDevelopmentTeam/papirus-smplayer-theme)<sup>aur</sup>：
 
@@ -188,36 +164,25 @@ DeaDBeeF 可以播放各种音频格式，在它们之间进行转换，以几�
 
 安装 [`deadbeef`](https://aur.archlinux.org/packages/deadbeef)<sup>cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S deadbeef
 ```
 
-:::
-::: code-group-item cn (git)
-
-```sh
+```sh [cn (git)]
 sudo pacman -S deadbeef-git
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/deadbeef
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aur/deadbeef-git
 ```
 
 :::
-::::
 
 ![deadbeef-1](../../assets/app/common/media/deadbeef-1.png)
 
@@ -283,22 +248,17 @@ yay -S listen1-desktop-appimage
 
 安装 [`netease-cloud-music`](https://aur.archlinux.org/packages/netease-cloud-music/)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S netease-cloud-music
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/netease-cloud-music
 ```
 
 :::
-::::
 
 ![netease-cloud-music](../../assets/app/common/media/netease-cloud-music.png)
 

--- a/docs/app/common/office.md
+++ b/docs/app/common/office.md
@@ -36,36 +36,25 @@ sidebarDepth: 2
 
 安装 WPS Office（可选 [国内版](https://aur.archlinux.org/packages/wps-office-cn/)<sup>EULA / aur</sup> 或 [国际版](https://aur.archlinux.org/packages/wps-office/)<sup>EULA / aur</sup>）以及 [相关字体](https://aur.archlinux.org/packages/ttf-wps-fonts/)<sup>EULA / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item cn (cn)
+::: code-group
 
-```sh
+```sh [cn (cn)]
 yay -S wps-office-cn ttf-wps-fonts
 ```
 
-:::
-::: code-group-item cn
-
-```sh
+```sh [cn]
 sudo pacman -S wps-office ttf-wps-fonts
 ```
 
-:::
-::: code-group-item aur (cn)
-
-```sh
+```sh [aur (cn)]
 yay -S wps-office-cn aur/ttf-wps-fonts
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 sudo pacman -S wps-office aur/ttf-wps-fonts
 ```
 
 :::
-::::
 
 ![wps-office](../../assets/app/common/office/wps-office.png)
 
@@ -81,22 +70,17 @@ sudo pacman -S wps-office aur/ttf-wps-fonts
 
 安装 [LibreOffice](https://archlinux.org/packages/extra/x86_64/libreoffice-still/) 以及 [其中文语言包](https://archlinux.org/packages/extra/any/libreoffice-still-zh-cn/)：
 
-:::: code-group
-::: code-group-item 正式版
+::: code-group
 
-```sh
+```sh [正式版]
 sudo pacman -S libreoffice-still libreoffice-still-zh-cn
 ```
 
-:::
-::: code-group-item 尝鲜版
-
-```sh
+```sh [尝鲜版]
 sudo pacman -S libreoffice-fresh libreoffice-fresh-zh-cn
 ```
 
 :::
-::::
 
 ![libreoffice-1](../../assets/app/common/office/libreoffice-1.png)
 
@@ -134,22 +118,17 @@ Typora 没有采用源代码和预览双栏显示的方式，而是采用所见�
 
 安装 [Typora](https://aur.archlinux.org/packages/typora/)<sup>EULA / cn / aur</sup> 以及 [Pandoc](https://archlinux.org/packages/community/x86_64/pandoc/)：
 
-:::: code-group
-::: code-group-item cn
+::: code-group
 
-```sh
+```sh [cn]
 sudo pacman -S typora pandoc
 ```
 
-:::
-::: code-group-item aur
-
-```sh
+```sh [aur]
 yay -S aur/typora pandoc
 ```
 
 :::
-::::
 
 值得注意的是，目前 typora 软件已经开始收费。如果有能力购买的话可以进行购买。对于囊中羞涩的学生党或其他不愿购买的用户，我们可以选择使用 typora 的最后一个免费版本（注意：不是盗版），安装方式如下：
 

--- a/docs/app/common/play.md
+++ b/docs/app/common/play.md
@@ -130,29 +130,21 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 1. 安装 [Lutris](https://archlinux.org/packages/community/any/lutris/)<sup>community / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S lutris
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/lutris
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S lutris-git
    ```
 
    :::
-   ::::
 
 2. 参考 [🍷 Wine](daily.md#🍷-wine) 安装 Wine
 
@@ -180,22 +172,17 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 1. 安装 [Minecraft Launcher（我的世界官服启动器）](https://aur.archlinux.org/packages/minecraft-launcher/)<sup>EULA / cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S minecraft-launcher
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/minecraft-launcher
    ```
 
    :::
-   ::::
 
    ::::: tip ℹ️ 提示
 
@@ -203,22 +190,17 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
    安装 [HMCL](https://aur.archlinux.org/packages/hmcl/)<sup>cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S hmcl
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/hmcl
    ```
 
    :::
-   ::::
 
    :::::
 
@@ -240,29 +222,21 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 1. 安装 [xow](https://aur.archlinux.org/packages/xow-git/)<sup>cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn (git)
+   ::: code-group
 
-   ```sh
+   ```sh [cn (git)]
    sudo pacman -S xow-git
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S xow
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S aur/xow-git
    ```
 
    :::
-   ::::
 
 2. 启动 `xcow` 服务：
 
@@ -280,22 +254,17 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 1. 安装 [MangoHud](https://aur.archlinux.org/pkgbase/mangohud/)<sup>aur</sup>：
 
-   :::: code-group
-   ::: code-group-item aur
+   ::: code-group
 
-   ```sh
+   ```sh [aur]
    yay -S mangohud lib32-mangohud
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S mangohud-git lib32-mangohud-git
    ```
 
    :::
-   ::::
 
 2. 通过以下方法使用 MangoHud：
 
@@ -403,32 +372,24 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 1. 安装 [OpenRGB](https://aur.archlinux.org/packages/openrgb/)<sup>cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S openrgb
    sudo pacman -S openrazer-driver-dkms # 雷蛇用户需要安装
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    yay -S aur/openrgb
    sudo pacman -S openrazer-driver-dkms # 雷蛇用户需要安装
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S openrgb-git
    yay -S openrazer-driver-dkms-git # 雷蛇用户需要安装
    ```
 
    :::
-   ::::
 
 2. 为了让内核能够识别到设备文件，需要下载 [60-openrgb.rules](https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/60-openrgb.rules)，并将它复制到 `/etc/udev/rules.d` 文件夹下：
 
@@ -450,45 +411,35 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
 4. 若显卡、内存条或者主板等带有 RGB 需要控制，则还需要载入额外的驱动：
 
-   :::: code-group
-   ::: code-group-item Intel
+   ::: code-group
 
-   ```sh
+   ```sh [Intel]
    sudo modprobe i2c-dev # 显卡、内存条
    sudo modprobe i2c-i801 # 芯片组
    ```
 
-   :::
-   ::: code-group-item AMD
-
-   ```sh
+   ```sh [AMD]
    sudo modprobe i2c-dev # 显卡、内存条
    sudo modprobe i2c-piix4 # 芯片组
    ```
 
    :::
-   ::::
 
    ![openrgb-3](../../assets/app/common/play/openrgb-3.png)
 
 5. 为了验证驱动载入情况，还需要安装 [I<sup>2</sup>C Tools](https://archlinux.org/packages/community/x86_64/i2c-tools/)<sup>community / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S i2c-tools
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S i2c-tools-git
    ```
 
    :::
-   ::::
 
    ![openrgb-4](../../assets/app/common/play/openrgb-4.png)
 

--- a/docs/app/exclusive/audio.md
+++ b/docs/app/exclusive/audio.md
@@ -34,22 +34,17 @@ sidebarDepth: 2
 
 安装 [Ardour](https://archlinux.org/packages/community/x86_64/ardour/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S ardour
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S ardour-git
 ```
 
 :::
-::::
 
 ![ardour](../../assets/app/exclusive/audio/ardour.png)
 
@@ -59,22 +54,17 @@ yay -S ardour-git
 
 安装 [Kwave](https://archlinux.org/packages/extra/x86_64/kwave/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S kwave
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S kwave-git
 ```
 
 :::
-::::
 
 ![kwave](../../assets/app/exclusive/audio/kwave.png)
 
@@ -84,22 +74,17 @@ yay -S kwave-git
 
 安装 [Audacity](https://archlinux.org/packages/community/x86_64/audacity/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S audacity
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S audacity-git
 ```
 
 :::
-::::
 
 ![audacity](../../assets/app/exclusive/audio/audacity.png)
 
@@ -129,29 +114,21 @@ yay -S audacium-git
 
 1. 安装 [VCV Rack](https://archlinux.org/packages/community/x86_64/audacity/)<sup>aur</sup>：
 
-   :::: code-group
-   ::: code-group-item aur (bin)
+   ::: code-group
 
-   ```sh
+   ```sh [aur (bin)]
    sudo pacman -S vcvrack-bin
    ```
 
-   :::
-   ::: code-group-item aur
-
-   ```sh
+   ```sh [aur]
    sudo pacman -S vcvrack
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S vcvrack-git
    ```
 
    :::
-   ::::
 
 2. 在终端通过 `vcvrack` 命令启动 VCV Rack：
 
@@ -165,22 +142,17 @@ yay -S audacium-git
 
 安装 [Mixxx](https://archlinux.org/packages/community/x86_64/mixxx/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S mixxx
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S mixxx-git
 ```
 
 :::
-::::
 
 ![mixxx](../../assets/app/exclusive/audio/mixxx.png)
 
@@ -192,22 +164,17 @@ yay -S mixxx-git
 
 安装 [LMMS](https://archlinux.org/packages/community/x86_64/lmms/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S lmms
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S lmms-git
 ```
 
 :::
-::::
 
 ![lmms](../../assets/app/exclusive/audio/lmms.png)
 
@@ -217,29 +184,21 @@ yay -S lmms-git
 
 安装 [MuseScore](https://archlinux.org/packages/community/x86_64/lmms/)<sup>community / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S musescore
 ```
 
-:::
-::: code-group-item cn (git)
-
-```sh
+```sh [cn (git)]
 sudo pacman -S musescore-git
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aur/musescore-git
 ```
 
 :::
-::::
 
 ![musescore](../../assets/app/exclusive/audio/musescore.png)
 
@@ -265,21 +224,16 @@ yay -S lyrebird
 
 安装 [SoundConverter](https://archlinux.org/packages/community/any/soundconverter/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S soundconverter
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S soundconverter-git
 ```
 
 :::
-::::
 
 ![soundconverter](../../assets/app/exclusive/audio/soundconverter.png)

--- a/docs/app/exclusive/image.md
+++ b/docs/app/exclusive/image.md
@@ -34,29 +34,21 @@ sidebarDepth: 2
 
 安装 [GIMP](https://archlinux.org/packages/extra/x86_64/gimp/)<sup>extra / cn / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S gimp
 ```
 
-:::
-::: code-group-item cn (git)
-
-```sh
+```sh [cn (git)]
 sudo pacman -S gimp-git
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aur/gimp-git
 ```
 
 :::
-::::
 
 ![gimp](../../assets/app/exclusive/image/gimp.png)
 
@@ -66,29 +58,21 @@ yay -S aur/gimp-git
 
 安装 [Aseprite](https://aur.archlinux.org/packages/aseprite/)<sup>EULA / aur</sup>：
 
-:::: code-group
-::: code-group-item aur
+::: code-group
 
-```sh
+```sh [aur]
 yay -S aseprite
 ```
 
-:::
-::: code-group-item aur (bin)
-
-```sh
+```sh [aur (bin)]
 yay -S aseprite-bin
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S aseprite-git
 ```
 
 :::
-::::
 
 ![aseprite](../../assets/app/exclusive/image/aseprite.png)
 
@@ -98,22 +82,17 @@ yay -S aseprite-git
 
 安装 [RawTherapee](https://archlinux.org/packages/community/x86_64/rawtherapee/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S rawtherapee
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S rawtherapee-git
 ```
 
 :::
-::::
 
 ![rawtherapee](../../assets/app/exclusive/image/rawtherapee.png)
 
@@ -123,22 +102,17 @@ KolourPaint 是 KDE 开发的一个简单易用的自由开源的绘图程序（
 
 安装 [KolourPaint](https://archlinux.org/packages/extra/x86_64/kolourpaint/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S kolourpaint
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S kolourpaint-git
 ```
 
 :::
-::::
 
 ![kolourpaint](../../assets/app/exclusive/image/kolourpaint.png)
 
@@ -150,22 +124,17 @@ Inkscape 是自由开源的矢量图形编辑器。该软件的开发目标是�
 
 安装 [Inkscape](https://archlinux.org/packages/extra/x86_64/inkscape/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S inkscape
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S inkscape-git
 ```
 
 :::
-::::
 
 ![inkscape](../../assets/app/exclusive/image/inkscape.png)
 
@@ -187,22 +156,17 @@ yay -S inkscape-git
 
 安装 [Krita](https://archlinux.org/packages/extra/x86_64/krita/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S krita
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S krita-git
 ```
 
 :::
-::::
 
 ![krita](../../assets/app/exclusive/image/krita.png)
 

--- a/docs/app/exclusive/media.md
+++ b/docs/app/exclusive/media.md
@@ -34,22 +34,17 @@ sidebarDepth: 2
 
 安装 [Blender](https://archlinux.org/packages/community/x86_64/blender/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S blender
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S blender-git
 ```
 
 :::
-::::
 
 ![blender](../../assets/app/exclusive/media/blender.png)
 
@@ -71,22 +66,17 @@ sudo pacman -S sweethome3d
 
 安装 [Synfig Studio](https://archlinux.org/packages/community/x86_64/synfigstudio/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S synfigstudio
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S synfigstudio-git
 ```
 
 :::
-::::
 
 ![synfigstudio](../../assets/app/exclusive/media/synfigstudio.png)
 
@@ -124,21 +114,16 @@ yay -S figma-linux
 
 安装 [FontForge](https://archlinux.org/packages/extra/x86_64/fontforge/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S fontforge
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S fontforge-git
 ```
 
 :::
-::::
 
 ![fontforge](../../assets/app/exclusive/media/fontforge.png)

--- a/docs/app/exclusive/video.md
+++ b/docs/app/exclusive/video.md
@@ -34,22 +34,17 @@ sidebarDepth: 2
 
 安装 [Kdenlive](https://archlinux.org/packages/extra/x86_64/kdenlive/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S kdenlive
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S kdenlive-git
 ```
 
 :::
-::::
 
 ![kdenlive](../../assets/app/exclusive/vedio/kdenlive.png)
 
@@ -59,22 +54,17 @@ yay -S kdenlive-git
 
 安装 [Shotcut](https://archlinux.org/packages/community/x86_64/shotcut/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item community
+::: code-group
 
-```sh
+```sh [community]
 sudo pacman -S shotcut
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S shotcut-git
 ```
 
 :::
-::::
 
 ![shotcut](../../assets/app/exclusive/vedio/shotcut.png)
 
@@ -84,22 +74,17 @@ yay -S shotcut-git
 
 安装 [MKVToolNix](https://archlinux.org/packages/extra/x86_64/mkvtoolnix-gui/)<sup>extra / aur</sup>：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```sh
+```sh [extra]
 sudo pacman -S mkvtoolnix-gui
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S mkvtoolnix-git
 ```
 
 :::
-::::
 
 ![mkvtoolnix-1](../../assets/app/exclusive/vedio/mkvtoolnix-1.png)
 
@@ -117,22 +102,17 @@ yay -S mkvtoolnix-git
 
 安装 [DaVinci Resolve（免费版）](https://aur.archlinux.org/packages/davinci-resolve/)<sup>EULA / aur</sup>：
 
-:::: code-group
-::: code-group-item aur
+::: code-group
 
-```sh
+```sh [aur]
 yay -S davinci-resolve
 ```
 
-:::
-::: code-group-item aur (beta)
-
-```sh
+```sh [aur (beta)]
 yay -S davinci-resolve-beta
 ```
 
 :::
-::::
 
 ::: tip ℹ️ 提示
 
@@ -144,22 +124,17 @@ DaVinci Resolve 没有编入 fcitx 模块，所以在 Linux 下不能输入中�
 
 另外还有 [DaVinci Resolve Studio（付费版）](https://aur.archlinux.org/packages/davinci-resolve-studio/)<sup>EULA / aur</sup>：
 
-:::: code-group
-::: code-group-item aur
+::: code-group
 
-```sh
+```sh [aur]
 yay -S davinci-resolve-studio
 ```
 
-:::
-::: code-group-item aur (beta)
-
-```sh
+```sh [aur (beta)]
 yay -S davinci-resolve-studio-beta
 ```
 
 :::
-::::
 
 ## 📡 录屏直播
 
@@ -169,29 +144,21 @@ yay -S davinci-resolve-studio-beta
 
 安装 [OBS Studio](https://www.archlinux.org/packages/community/x86_64/obs-studio/)<sup>community / aur</sup>：
 
-:::: code-group
-::: code-group-item aur (browser)
+::: code-group
 
-```sh
+```sh [aur (browser)]
 yay -S obs-studio-browser # 有浏览器插件集成的 OBS Studio。编译要很久（大约 15 min）
 ```
 
-:::
-::: code-group-item community
-
-```sh
+```sh [community]
 sudo pacman -S obs-studio
 ```
 
-:::
-::: code-group-item aur (git)
-
-```sh
+```sh [aur (git)]
 yay -S obs-studio-git
 ```
 
 :::
-::::
 
 ![obs-studio](../../assets/app/exclusive/vedio/obs-studio.png)
 
@@ -280,29 +247,21 @@ yay -S obs-nvfbc-git
 
 1. 安装 [弹幕库](https://www.danmaku.live/)<sup>cn / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item cn
+   ::: code-group
 
-   ```sh
+   ```sh [cn]
    sudo pacman -S bilibili-live-helper-bin
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S aur/bilibili-live-helper-bin
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S bilibili-live-helper-git
    ```
 
    :::
-   ::::
 
    ![danmaku-1](../../assets/app/exclusive/vedio/danmaku-1.png)
 
@@ -316,22 +275,17 @@ yay -S obs-nvfbc-git
 
 1. 安装 [screenkey](https://archlinux.org/packages/community/any/screenkey/)<sup>community / aur</sup>：
 
-   :::: code-group
-   ::: code-group-item community
+   ::: code-group
 
-   ```sh
+   ```sh [community]
    sudo pacman -S screenkey
    ```
 
-   :::
-   ::: code-group-item aur (git)
-
-   ```sh
+   ```sh [aur (git)]
    yay -S screenkey-git
    ```
 
    :::
-   ::::
 
 2. 在终端输入 `screenkey` 以启动：
 

--- a/docs/guide/advanced/optional-cfg-2.md
+++ b/docs/guide/advanced/optional-cfg-2.md
@@ -112,22 +112,17 @@ sudo vim /boot/efi/EFI/refind/refind.conf
 
 6. 使用以下命令查看内核：
 
-:::: code-group
-::: code-group-item uname
+::: code-group
 
-```bash
+```bash [uname]
 uname -r
 ```
 
-:::
-::: code-group-item neofetch
-
-```bash
+```bash [neofetch]
 neofetch
 ```
 
 :::
-::::
 
 ![kernel-version-1](../../assets/guide/advanced/optional-cfg/kernel-version-1.png)
 
@@ -153,29 +148,23 @@ KDE 自身提供开箱即用的睡眠功能（sleep），即将系统挂起到�
 
 1. 通过以下命令确认 Swap 分区的 `UUID`：
 
-:::: code-group
-::: code-group-item lsblk
+::: code-group
 
-```bash {8}
+```bash {8} [lsblk]
 lsblk -o name,mountpoint,size,uuid
 ```
 
-:::
-::: code-group-item blkid
-
-```bash
+```bash [blkid]
 sudo blkid
 ```
 
 :::
-::::
 
 输出结果应类似：
 
-:::: code-group
-::: code-group-item lsblk
+::: code-group
 
-```bash {6}
+```bash {6} [lsblk]
 NAME   MOUNTPOINT              SIZE UUID
 sda                             64G
 ├─sda1 /boot/efi               244M E519-88D8
@@ -186,10 +175,7 @@ sda                             64G
 sr0                          755.3M 2021-05-01-05-18-20-00
 ```
 
-:::
-::: code-group-item blkid
-
-```bash {2}
+```bash {2} [blkid]
 /dev/sr0: BLOCK_SIZE="2048" UUID="2021-05-01-05-18-20-00" LABEL="ARCH_202105" TYPE="iso9660" PTTYPE="PMBR"
 /dev/sda4: UUID="13ec7b86-eb9c-45a9-ae50-9606279b506a" TYPE="swap" PARTUUID="7a9e75d7-eca2-c849-9372-85c6889a7861"
 /dev/sda2: PARTUUID="bfc5f742-be1e-cb41-911f-ec5466d670de"
@@ -199,7 +185,6 @@ sr0                          755.3M 2021-05-01-05-18-20-00
 ```
 
 :::
-::::
 
 > #### 📑 相关资料：UUID
 >

--- a/docs/guide/advanced/system-ctl.md
+++ b/docs/guide/advanced/system-ctl.md
@@ -270,22 +270,17 @@ df -h # 以人类可读格式显示
 
 1. 安装 Filelight：
 
-:::: code-group
-::: code-group-item extra
+::: code-group
 
-```bash
+```bash [extra]
 sudo pacman -S filelight
 ```
 
-:::
-::: code-group-item aur (git)
-
-```bash
+```bash [aur (git)]
 yay -S filelight-git
 ```
 
 :::
-::::
 
 2. 打开 Filelight 即可直观的看到空间占用情况：
 


### PR DESCRIPTION
After migrating from vuepress to vitepress, the `code-group` error has not been fixed for a long time, so I fixed it. 
Part of it was modified manually, and the other part was written a python script to repair it.

The corresponding script is as follows:

```python
import re

filePath = "./arch-guide/docs/guide/advanced/system-ctl.md"

data = ""

with open(filePath, "r") as f: 
    data = f.read()
    f.close()


p = re.compile(r":::: code-group\n(.+?):::\n([\s]*)::::", re.S)
data = p.sub( r'::: code-group\n\1\n\2:::', data)

p = re.compile(r"(::: code-group-item (.+?)[\s]+```(.+?)\n)", re.S)
data = p.sub( r'```\3 [\2]\n', data)


p = re.compile(r"```([\s]+):::([\s]+)```", re.S)
data = p.sub( r'```\2```', data)


with open(filePath, "w") as f:  
    f.write(data)
    f.close()
```

It was written roughly, but I made sure it passed the build test and I didn't find any problems.