### PR TITLE
增加了禁止自动播放视频

### DIFF
--- a/docs/app/common/collaboration.md
+++ b/docs/app/common/collaboration.md
@@ -241,7 +241,7 @@ echo 'alias scrcpy="scrcpy --turn-screen-off --stay-awake"' >> ~/.zshrc
 >
   <iframe
     style="position: absolute; width: 100%; height: 100%; left: 0; top: 0"
-    src="//player.bilibili.com/player.html?aid=972705991&bvid=BV1fp4y1t71r&cid=328263624&page=1&as_wide=1&high_quality=1&danmaku=1"
+    src="//player.bilibili.com/player.html?aid=972705991&bvid=BV1fp4y1t71r&cid=328263624&page=1&as_wide=1&high_quality=1&danmaku=1&autoplay=0"
     scrolling="no"
     border="0"
     frameborder="no"

--- a/docs/app/common/daily.md
+++ b/docs/app/common/daily.md
@@ -277,7 +277,7 @@ yay -S calibre-git
 >
   <iframe
     style="position: absolute; width: 100%; height: 100%; left: 0; top: 0"
-    src="//player.bilibili.com/player.html?aid=417575346&bvid=BV1hV411H7Sf&cid=322832461&page=1&as_wide=1&high_quality=1&danmaku=1"
+    src="//player.bilibili.com/player.html?aid=417575346&bvid=BV1hV411H7Sf&cid=322832461&page=1&as_wide=1&high_quality=1&danmaku=1&autoplay=0"
     scrolling="no"
     border="0"
     frameborder="no"


### PR DESCRIPTION
### 问题描述
访问 [常用软件 | archlinux简明指南](https://arch.icekylin.online/app/common/daily.html)和[多屏协同 | archlinux简明指南](https://arch.icekylin.online/app/common/collaboration.html) 的时候会自动开始播放视频。

### 解决方案
在html`<iframe>`的`src`地址中加上参数`autoplay=0`

### 结果
成功解决问题，不再自动播放。