### PR TITLE
增加文档说明

### DIFF
--- a/docs/app/common/play.md
+++ b/docs/app/common/play.md
@@ -97,6 +97,32 @@ sudo pacman -S steam
 
 :::
 
+管理第三方 proton 的版本，我们可以使用[protonup-qt](https://aur.archlinux.org/packages/protonup-qt)<sup>aur</sup>
+
+::: tip ℹ️ 提示
+
+该工具运行后会自动识别 proton,并且可以配置每个游戏使用的 proton 版本
+
+:::
+
+```sh
+yay -S protonup-qt
+```
+
+为 proton 的游戏安装游戏补丁，我们可以使用[protontricks](https://aur.archlinux.org/packages/protontricks)<sup>aur</sup>
+
+```sh
+yay -S protontricks
+```
+
+::: tip ℹ️ 提示
+
+覆盖文件类型补丁，直接通过 protontricks 找到游戏文件夹 id 覆盖即可
+
+exe 可执行文件型补丁需要使用 protontricks 并且选择对应的游戏 id 环境运行安装
+
+:::
+
 ## 👾 Lutris
 
 [Lutris](https://lutris.net/) 是 Linux 上的开源游戏平台。可以使用 Lutris 安装、移除、配置、启动和管理游戏。它可以在一个单一界面中管理的 Linux 游戏、Windows 游戏、仿真控制台游戏和浏览器游戏。它还包含社区编写的安装脚本，使得游戏的安装过程更加简单。
@@ -186,7 +212,7 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
    ::::: tip ℹ️ 提示
 
-   除了官方启动器，还有第三方启动器 [HMCL（Hello Minecraft! Launcher）](https://hmcl.huangyuhui.net/)，支持模组管理、游戏定制、自动安装（Forge、LiteLoader 和 OptiFine）、模组包创建、UI 定制等。同时，国产第三方启动器如hmcl一般支持使用国内镜像源下载游戏，而非使用在国内访问不稳定的官方源下载游戏。
+   除了官方启动器，还有第三方启动器 [HMCL（Hello Minecraft! Launcher）](https://hmcl.huangyuhui.net/)，支持模组管理、游戏定制、自动安装（Forge、LiteLoader 和 OptiFine）、模组包创建、UI 定制等。同时，国产第三方启动器如 hmcl 一般支持使用国内镜像源下载游戏，而非使用在国内访问不稳定的官方源下载游戏。
 
    安装 [HMCL](https://aur.archlinux.org/packages/hmcl/)<sup>cn / aur</sup>：
 
@@ -202,15 +228,15 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
    :::
 
-   出于安全性的考虑，hmcl仅在官方提供的构建版本才会包含微软登录功能。为了登陆正版账户，我们可以使用[hmcl-bin](https://aur.archlinux.org/packages/hmcl-bin)<sup>aur</sup>作为启动器：
+   出于安全性的考虑，hmcl 仅在官方提供的构建版本才会包含微软登录功能。为了登陆正版账户，我们可以使用[hmcl-bin](https://aur.archlinux.org/packages/hmcl-bin)<sup>aur</sup>作为启动器：
 
    ```sh [aur]
    yay -S hmcl-bin
    ```
-   
-​   使用[hmcl-bin](https://aur.archlinux.org/packages/hmcl-bin)<sup>aur</sup>在让我们获取良好的官方支持以外，还能够让其自身使用系统的java-openjfx包，符合「低耦合、高内聚」的软件工程原则。
 
-   :::
+​ 使用[hmcl-bin](https://aur.archlinux.org/packages/hmcl-bin)<sup>aur</sup>在让我们获取良好的官方支持以外，还能够让其自身使用系统的 java-openjfx 包，符合「低耦合、高内聚」的软件工程原则。
+
+:::
 
 2. 打开 `Minecraft Launcher` > 根据提示登录帐号并下载主程序后即可畅玩：
 
@@ -323,7 +349,7 @@ Lutris 支持超过 20 个模拟器并且提供了从七十年代到现在的大
 
    ```sh
    # 进入下载配置文件的文件夹
-   sudo cp gamemode.ini ~/.config/gamemode.ini
+   cp gamemode.ini ~/.config/gamemode.ini
    # 注意：需要将当前用户名添加到gamemode用户组
    sudo usermod -aG gamemode username
    ```

--- a/docs/guide/advanced/beauty-3.md
+++ b/docs/guide/advanced/beauty-3.md
@@ -74,7 +74,31 @@ sudo pacman -S ttf-jetbrains-mono-nerd
 
 现在再打开 `powerlevel10k` 配置（`p10k configure`），就可以看到图标符号，正常配置了。
 
-## 3. vim 美化
+<!-- ## 3. vim 美化 -->
+
+## 3. fish 配置
+
+fish 是另一个 shell，名字是"**\*f**riendly **i**nteractive **sh**ell\*"的缩写，作为一个友好交互式的命令行 shell
+
+::: tip ℹ️ 提示
+需要注意，fish 本身和 bash 并不完全兼容（但有方法可以直接运行 bash 格式的脚本）
+:::
+
+```sh
+sudo pacman -S fish
+```
+
+fish 本身自带补全，所需要做的仅仅是少量美化，我们可以选择[starship](https://starship.rs/)
+
+```sh
+sudo pacman -S starship
+```
+
+编辑文件`~/.config/fish/config.fish`添加以下内容:
+
+```sh
+starship init fish | source
+```
 
 ## 4. ASCII 艺术与终端玩具
 
@@ -236,4 +260,4 @@ sudo pacman -S ttf-jetbrains-mono-nerd
 
    ![sl](../../assets/guide/advanced/beauty/sl.png)
 
-## 5. Linux 彩蛋
+<!-- ## 5. Linux 彩蛋 -->

--- a/docs/guide/advanced/optional-cfg-2.md
+++ b/docs/guide/advanced/optional-cfg-2.md
@@ -62,6 +62,10 @@ sudo pacman -S linux-hardened linux-hardened-headers
 
 2. 为了让 GRUB 记住最后在 GRUB 引导菜单里选择的内核，以便在下次启动时自动使用对应的内核，需要编辑 `/etc/default/grub` 文件：
 
+::: tip ℹ️ 提示
+当前 btrfs 并不支持记住上次选择内核，btrfs 用户请勿配置
+:::
+
 ```bash
 sudo vim /etc/default/grub
 ```

--- a/docs/guide/advanced/power-ctl.md
+++ b/docs/guide/advanced/power-ctl.md
@@ -4,6 +4,20 @@
 >
 > 针对散热不好的设备或者续航能力不佳的笔记本，功耗控制显得非常必要
 
+## 使用 KDE 本身的电源管理
+
+安装 [powerdevil](https://archlinux.org/packages/extra/x86_64/powerdevil/)<sup>extra</sup>、[power-profiles-daemon](https://archlinux.org/packages/extra/x86_64/power-profiles-daemon/)<sup>extra</sup>
+
+```bash
+sudo pacman -S powerdevil power-profiles-daemon
+```
+
+安装完成后重启系统即可在 kde 右下角托盘`电池与亮度`对电源配置进行调节
+
+::: tip ℹ️ 提示
+使用 KDE 本身的电源配置后不建议继续使用下文所述的其他方案
+:::
+
 ## 使用 TLP 延长电池寿命及续航
 
 > 🔗 相关链接：

--- a/docs/guide/rookie/basic-install.md
+++ b/docs/guide/rookie/basic-install.md
@@ -378,11 +378,11 @@ lsblk # 复查磁盘情况
 ::: code-group
 
 ```zsh [SATA]
-mkfs.fat -F32 /dev/sdxn
+mkfs.fat -F 32 /dev/sdxn
 ```
 
 ```zsh [NVME]
-mkfs.fat -F32 /dev/nvmexn1pn
+mkfs.fat -F 32 /dev/nvmexn1pn
 ```
 
 :::
@@ -848,7 +848,7 @@ grub-mkconfig -o /boot/grub/grub.cfg
 
 ![os-prober-1](../../assets/guide/rookie/basic-install/os-prober-1.png)
 
-若win10安装在另一个硬盘中则不会输出
+若 win10 安装在另一个硬盘中则不会输出
 可在进入系统后挂载硬盘并重新执行该命令
 
 ::: tip ℹ️ 提示

--- a/docs/guide/rookie/desktop-env-and-app.md
+++ b/docs/guide/rookie/desktop-env-and-app.md
@@ -201,7 +201,7 @@ pacman -S plasma-meta konsole dolphin # plasma-meta 元软件包、konsole 终�
 
 2. kde 默认安装的是[xorg](https://wiki.archlinuxcn.org/zh-hans/Xorg)，如果想使用[wayland](https://wiki.archlinuxcn.org/wiki/Wayland)的话安装以下包：
 
-```
+```bash
 pacman -S  plasma-wayland-session xdg-desktop-portal
 # N卡用户需要额外安装egl-wayland,xdg-desktop-portal包是为了如obs此类工具录制屏幕使用
 ```


### PR DESCRIPTION
- steam使用protonup-qt和protontricks进行proton管理
- 修正gamemode的配置文件复制命令无需sudo
- 终端配置中增加fish配置，并注释无内容的vim和linux彩蛋部分
- 增加使用KDE本身的电源管理说明
- 修正几个文本错误