### PR TITLE
docs(desktop-env-and-app.md):补充说明

### DIFF
--- a/docs/guide/rookie/desktop-env-and-app.md
+++ b/docs/guide/rookie/desktop-env-and-app.md
@@ -204,6 +204,8 @@ pacman -S plasma-meta konsole dolphin # plasma-meta 元软件包、konsole 终�
 ```
 pacman -S  plasma-wayland-session xdg-desktop-portal
 # N卡用户需要额外安装egl-wayland,xdg-desktop-portal包是为了如obs此类工具录制屏幕使用
+# xdg-desktop-portal包组提供了不同环境下使用的软件包
+# 例如kde用户可选择xdg-desktop-portal-kde包
 ```
 
 3. 安装完成后，可以在后续登录时选择使用 xorg 还是 wayland


### PR DESCRIPTION
安装xdg-desktop-portal包组时，有针对多个环境后端的包，参考[archwiki](https://wiki.archlinux.org/title/XDG_Desktop_Portal)。如果按教程使用的kde桌面，那么应安装xdg-desktop-portal-kde包，默认情况下用户直接安装的可能是xdg-desktop-portal-gnome包。