### PR TITLE
Add enable cronie service for Timeshift

### DIFF
--- a/docs/guide/rookie/desktop-env-and-app.md
+++ b/docs/guide/rookie/desktop-env-and-app.md
@@ -461,6 +461,12 @@ yay -S aur/timeshift
 
 :::
 
+安装之后，如果 Timeshift 没有自动备份，需要手动开启`cronie`服务：
+
+```bash
+sudo systemctl enable --now cronie.service
+```
+
 2. 打开 Timeshift，第一次启动会自动启动设置向导
 
 ### 12-1. 若使用 Btrfs 文件系统


### PR DESCRIPTION
默认情况下，可能出现安装Timeshift没有自动备份的情况，这是因为`cronie`服务没有启动，需要手动启动一下。