### PR TITLE
Update office.md

### DIFF
--- a/docs/app/common/office.md
+++ b/docs/app/common/office.md
@@ -39,7 +39,7 @@ sidebarDepth: 2
 ::: code-group
 
 ```sh [cn (cn)]
-yay -S wps-office-cn ttf-wps-fonts libtiff5
+yay -S wps-office-cn wps-office-mui-zh-cn ttf-wps-fonts
 ```
 
 ```sh [cn]


### PR DESCRIPTION
![image](https://github.com/nakanomikuorg/arch-guide/assets/81098819/20ea2aed-e49d-4391-b9aa-3406dff8cb5a)

根据 Archlinuxcn：中文使用者还需要安装中文语言包：[wps-office-mui-zh-cn](https://aur.archlinux.org/packages/wps-office-mui-zh-cn/)AUR

而 libtiff5 是可选的 WPS PDF 支持，我认为这个可以让用户选择，因为 okular 已经足够使用