### PR TITLE
Update basic-install.md

### DIFF
--- a/docs/guide/rookie/basic-install.md
+++ b/docs/guide/rookie/basic-install.md
@@ -836,6 +836,12 @@ GRUB_DISABLE_OS_PROBER=false
 ...
 ```
 
+::: tip ℹ️ 提示
+
+`nowatchdog` 参数无法禁用英特尔的看门狗硬件，改为 `modprobe.blacklist=iTCO_wdt` 即可。如有需要可以参考 [ArchWiki 对应内容](https://wiki.archlinuxcn.org/wiki/性能优化#看门狗)
+
+:::
+
 4. 最后生成 `GRUB` 所需的配置文件：
 
 ```bash


### PR DESCRIPTION
Update instructions for disabling watchdog

- The `nowatchdog` parameter does not work for Intel TCO hardware watchdog
- Update the document to suggest using `modprobe.blacklist=iTCO_wdt`
- Add a reference link to ArchWiki

更新手册中关于禁用watchdog的说明

- 原手册中提及使用 `nowatchdog` 参数来禁用看门狗，但这并不适用于 Intel TCO 硬件看门狗。
- 更新内容指出，应使用 `modprobe.blacklist=iTCO_wdt` 来禁用英特尔的看门狗硬件。
- 添加 ArchWiki 相关内容链接，以供获取更多信息。