### PR TITLE
fix zsh highlight setting

### DIFF
--- a/docs/guide/advanced/optional-cfg-1.md
+++ b/docs/guide/advanced/optional-cfg-1.md
@@ -416,9 +416,9 @@ sudo vim root/.zshrc
 将以下内容分别添加到需要设置 zsh 账户的 `~/.zshrc` 中：
 
 ```zsh
-source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
 source /usr/share/autojump/autojump.zsh
+source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 ```
 
 ![zsh_step-6](../../assets/guide/advanced/optional-cfg/zsh-6.png)


### PR DESCRIPTION
根据[zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) 的github主页

> ### Why must `zsh-syntax-highlighting.zsh` be sourced at the end of the `.zshrc` file?
>
> zsh-syntax-highlighting works by hooking into the Zsh Line Editor (ZLE) and computing syntax highlighting for the command-line buffer as it stands at the time z-sy-h's hook is invoked.
>
> In zsh 5.2 and older, `zsh-syntax-highlighting.zsh` hooks into ZLE by wrapping ZLE widgets. It must be sourced after all custom widgets have been created (i.e., after all `zle -N` calls and after running `compinit`) in order to be able to wrap all of them. Widgets created after z-sy-h is sourced will work, but will not update the syntax highlighting.
>
> In zsh newer than 5.8 (not including 5.8 itself), zsh-syntax-highlighting uses the `add-zle-hook-widget` facility to install a `zle-line-pre-redraw` hook. Hooks are run in order of registration, therefore, z-sy-h must be sourced (and register its hook) after anything else that adds hooks that modify the command-line buffer.

在高于5.8版本的zsh中，`zsh-syntax-highlighting.zsh`需要在文件的末尾被引用才能正确的注册hook并生效