### PR TITLE
推荐用freetype2-wps解决WPS字体过粗问题

### DIFF
--- a/docs/app/common/office.md
+++ b/docs/app/common/office.md
@@ -60,9 +60,11 @@ sudo pacman -S wps-office aur/ttf-wps-fonts aur/libtiff5
 
 ::: tip ℹ️ 提示
 
-WPS 可能会出现部分中文字体过粗的情况。文本看起来特别粗，标题、粗体文本几乎不可用。
+WPS 可能会出现部分中文字体过粗的情况。文本看起来特别粗，标题、粗体文本几乎不可用。可以通过安装`freetype2-wps`<sup>aur</sup>解决。
 
-可以通过降级`freetype2`至 2.13.0 版本解决。
+```bash
+yay -S freetype2-wps
+```
 
 WPS PDF 可能会出现无法导出 pdf 或者无法打开的情况，通过安装`libtiff5`即可解决。
 


### PR DESCRIPTION
freetype2-wps包将打过workaround补丁的最新版freetype2安装到WPS的库目录。

不应仅因WPS的问题就降级freetype2软件包。