### PR TITLE
Added `sddm` installation and documented `linux-headers` and `linux-firmware`.

### DIFF
--- a/docs/guide/advanced/optional-cfg-2.md
+++ b/docs/guide/advanced/optional-cfg-2.md
@@ -49,6 +49,8 @@ sudo pacman -S linux-hardened linux-hardened-headers
 
 更换内核后还需要留意部分应用需要更换为相应的 dkms 版本。
 
+相反的，如果你使用了 dkms 版本的应用，请保证你安装了对应内核头文件。
+
 本指南涉及的应用如下：
 
 - [`nvidia-dkms`](/guide/rookie/graphic-driver.md#nvidia-独立显卡)
@@ -56,9 +58,10 @@ sudo pacman -S linux-hardened linux-hardened-headers
 
 :::
 
-> #### 📑 相关资料：DKMS
+> #### 📑 相关资料
 >
-> DKMS，即 **D**ynamic **K**ernel **M**odule **S**ystem。可以使内核变更（如升级）后自动编译模块，适配新内核。
+> - DKMS，即 **D**ynamic **K**ernel **M**odule **S**ystem。可以使内核变更（如升级）后自动编译模块，适配新内核。
+> - 内核头文件（Kernel Headers）是编译内核模块所需的接口文件。Arch Linux 中对应的软件包通常为 `linux-headers`，其中包含当前 Linux 内核版本的头文件，用于编译 NVIDIA DKMS 驱动、VirtualBox、ZFS 等第三方内核模块。
 
 2. 为了让 GRUB 记住最后在 GRUB 引导菜单里选择的内核，以便在下次启动时自动使用对应的内核，需要编辑 `/etc/default/grub` 文件：
 

--- a/docs/guide/rookie/basic-install.md
+++ b/docs/guide/rookie/basic-install.md
@@ -37,6 +37,7 @@
 :::
 
 ::: tip ℹ️ 提示
+
 - 在命令行中你可以使用如下命令清屏：
 
   ```zsh
@@ -50,6 +51,7 @@
   ```zsh
   rmmod pcspkr
   ```
+
 - 要永久禁用蜂鸣器内核模块, 请创建并编辑 `/etc/modprobe.d/blacklist.conf`
 
   ```zsh
@@ -559,6 +561,7 @@ pacstrap /mnt base base-devel linux linux-firmware btrfs-progs
 >
 > - `base-devel` —— `base-devel` 在 `AUR` 包的安装过程中是必须用到的
 > - `linux` —— 内核软件包，这里建议先不要替换为其它内核
+> - `linux-firmware` —— 硬件固件软件包，包含显卡、无线网卡、蓝牙等设备运行所需的固件文件
 
 ![pacstrap_step-1](../../assets/guide/rookie/basic-install_pacstrap-1.png)
 
@@ -945,7 +948,6 @@ nmtui
 neofetch 原作者 dylanaraps 已于 2024 年 04 月 26 日归档 neofetch 仓库，在下面我们会使用 `fastfetch` 代替 `neofetch`。
 
 :::
-
 
 5. `fastfetch` 可以将系统信息和发行版 logo 一并打印出来。通过 `pacman` 安装 `fastfetch`：
 

--- a/docs/guide/rookie/desktop-env-and-app.md
+++ b/docs/guide/rookie/desktop-env-and-app.md
@@ -198,8 +198,15 @@ pacman -Syyu
 1. 通过以下命令安装相关软件包：
 
 ```bash
-pacman -S plasma-meta konsole dolphin # plasma-meta 元软件包、konsole 终端模拟器和 dolphin 文件管理器
+pacman -S plasma-meta konsole dolphin sddm
 ```
+
+> 📑 命令参数说明：
+>
+> - `plasma-meta` —— KDE Plasma 桌面元软件包，安装 KDE 桌面环境的核心组件（如 Plasma Shell、KWin 窗口管理器、系统设置等）
+> - `konsole` —— KDE 默认终端模拟器，用于执行命令
+> - `dolphin` —— KDE 默认文件管理器，用于浏览和管理文件
+> - `sddm` —— KDE 推荐的显示管理器，提供图形化登录界面，并负责在系统启动后启动 KDE Plasma 会话
 
 ![install-kde](../../assets/guide/rookie/desktop-env-and-app_install-kde.png)
 


### PR DESCRIPTION
1. Added `sddm` to the `plasma-meta` installation command. Previously, failing to install `sddm` alongside KDE Plasma could prevent users from entering KDE after reboot.
2. Added an explanation of kernel headers and noted that users who switch kernels or use DKMS-based drivers should install `linux-headers`.
3. Also added an explanation of `linux-firmware`.